### PR TITLE
add tensorflow-gpu version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+tensorflow-gpu==1.13.1
 Pillow==6.0.0
 h5py==2.9.0
 tqdm==4.32.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow-gpu==1.13.1
 Pillow==6.0.0
 h5py==2.9.0
 tqdm==4.32.1
+tensorflow-gpu==1.13.1


### PR DESCRIPTION
Considering to add SRCNN in deep-patch-score-map...

Adding tensorflow-gpu version in `requirements.txt` would be convenient for conda or other virtual-env users.